### PR TITLE
Fix for export error

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,4 +1,4 @@
-export module "recombee-api-client" {
+declare module "recombee-api-client" {
   namespace requests {
     /**
      * Base class for all the requests


### PR DESCRIPTION
Whenever I try to add this to a typescript project, I get the following error:

node_modules/recombee-api-client/lib/index.d.ts:1:1 - error TS2668: 'export' modifier cannot be applied to ambient modules and module augmentations since they are always visible.

Changing "export" to "declare" appears to fix the problem.